### PR TITLE
Additions to 4.x conversion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,9 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-Varnish Module (vmod) for sending statistics to Statsd.
+Varnish 4.x Module (vmod) for sending statistics to Statsd.
+
+See https://github.com/jib/libvmod-statsd/tree/master for Varnish 3.x version.
 
 See https://github.com/etsy/statsd for documentation on Statsd.
 
@@ -190,11 +192,7 @@ Usage::
  ./autogen.sh
 
  # Execute configure script
- ./configure VARNISHSRC=DIR [VMODDIR=DIR]
-
-`VARNISHSRC` is the directory of the Varnish source tree for which to
-compile your vmod. Both the `VARNISHSRC` and `VARNISHSRC/include`
-will be added to the include search paths for your module.
+ ./configure
 
 Optionally you can also set the vmod install directory by adding
 `VMODDIR=DIR` (defaults to the pkg-config discovered directory from your

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,4 +25,7 @@ EXTRA_DIST = \
 	vmod_statsd.vcc \
 	$(VMOD_TESTS)
 
-CLEANFILES = $(builddir)/vcc_if.c $(builddir)/vcc_if.h
+CLEANFILES = $(builddir)/vcc_if.c $(builddir)/vcc_if.h \
+	$(builddir)/vmod_statsd.man.rst \
+	$(builddir)/vmod_statsd.rst \
+	$(builddir)/../vmod_statsd.3


### PR DESCRIPTION
As explained here (https://github.com/jib/libvmod-statsd/pull/11), I've made a PR for 4.x conversion before seeing yours.

Both PR were very close. Yours is better at code level. Here are some additions I suggest for your PR (hoping it will be merged soon ;o)):
- Cleaning of generated RST files with `make clean`
- Removal of `VARNISHSRC` and notification about 4.x compatibility in the README
